### PR TITLE
Support feedback for individual prompts

### DIFF
--- a/app/components/chat/ApproveChange.tsx
+++ b/app/components/chat/ApproveChange.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+
+interface ApproveChangeProps {
+  onApprove: () => void;
+  onReject: () => void;
+}
+
+const ApproveChange: React.FC<ApproveChangeProps> = ({ onApprove, onReject }) => {
+  return (
+    <div className="flex items-center gap-1 w-full h-[30px] pt-2">
+      <button
+        onClick={onReject}
+        className="flex-1 h-[30px] flex justify-center items-center bg-red-100 border border-red-500 text-red-500 hover:bg-red-200 hover:text-red-600 transition-colors rounded"
+        aria-label="Reject change"
+        title="Reject change"
+      >
+        <div className="i-ph:thumbs-down-bold"></div>
+      </button>
+      <button
+        onClick={onApprove}
+        className="flex-1 h-[30px] flex justify-center items-center bg-green-100 border border-green-500 text-green-500 hover:bg-green-200 hover:text-green-600 transition-colors rounded"
+        aria-label="Approve change"
+        title="Approve change"
+      >
+        <div className="i-ph:thumbs-up-bold"></div>
+      </button>
+    </div>
+  );
+};
+
+export default ApproveChange;

--- a/app/components/chat/ApproveChange.tsx
+++ b/app/components/chat/ApproveChange.tsx
@@ -1,20 +1,33 @@
-import React, { useState } from 'react';
+import React, { useRef, useState } from 'react';
 import { classNames } from '~/utils/classNames';
 import { TEXTAREA_MIN_HEIGHT } from './BaseChat';
 
+export interface RejectChangeData {
+  explanation: string;
+  shareProject: boolean;
+  retry: boolean;
+}
+
 interface ApproveChangeProps {
   onApprove: () => void;
-  onReject: () => void;
+  onReject: (data: RejectChangeData) => void;
 }
 
 const ApproveChange: React.FC<ApproveChangeProps> = ({ onApprove, onReject }) => {
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
   const [hasRejected, setHasRejected] = useState(false);
-
-  const onStartReject = () => {
-    setHasRejected(true);
-  };
+  const [shareProject, setShareProject] = useState(false);
 
   if (hasRejected) {
+    const performReject = (retry: boolean) => {
+      const explanation = textareaRef.current?.value ?? '';
+      onReject({
+        explanation,
+        shareProject,
+        retry,
+      });
+    };
+
     return (
       <>
         <div
@@ -23,6 +36,7 @@ const ApproveChange: React.FC<ApproveChangeProps> = ({ onApprove, onReject }) =>
           )}
         >
           <textarea
+            ref={textareaRef}
             className={classNames(
               'w-full pl-4 pt-4 pr-25 outline-none resize-none text-bolt-elements-textPrimary placeholder-bolt-elements-textTertiary bg-transparent text-sm',
               'transition-all duration-200',
@@ -35,21 +49,24 @@ const ApproveChange: React.FC<ApproveChangeProps> = ({ onApprove, onReject }) =>
                 }
 
                 event.preventDefault();
+                performReject(true);
               }
             }}
             style={{
               minHeight: TEXTAREA_MIN_HEIGHT,
               maxHeight: 400,
             }}
-            placeholder="What is wrong with our changes?"
+            placeholder="What's wrong with the changes?"
             translate="no"
           />
         </div>
-        
+
         <div className="flex items-center gap-2 w-full mb-2">
           <input
             type="checkbox"
             id="share-project"
+            checked={shareProject}
+            onChange={(event) => setShareProject(event.target.checked)}
             className="rounded border-red-300 text-red-500 focus:ring-red-500"
           />
           <label htmlFor="share-project" className="text-sm text-red-600">
@@ -59,7 +76,7 @@ const ApproveChange: React.FC<ApproveChangeProps> = ({ onApprove, onReject }) =>
 
         <div className="flex items-center gap-1 w-full h-[30px] pt-2">
           <button
-            onClick={() => {}}
+            onClick={() => performReject(false)}
             className="flex-1 h-[30px] flex justify-center items-center bg-red-100 border border-red-500 text-red-500 hover:bg-red-200 hover:text-red-600 transition-colors rounded"
             aria-label="Cancel changes"
             title="Cancel changes"
@@ -67,7 +84,7 @@ const ApproveChange: React.FC<ApproveChangeProps> = ({ onApprove, onReject }) =>
             <div className="i-ph:x-bold"></div>
           </button>
           <button
-            onClick={() => {}}
+            onClick={() => performReject(true)}
             className="flex-1 h-[30px] flex justify-center items-center bg-green-100 border border-green-500 text-green-500 hover:bg-green-200 hover:text-green-600 transition-colors rounded"
             aria-label="Try changes again"
             title="Try changes again"
@@ -82,7 +99,7 @@ const ApproveChange: React.FC<ApproveChangeProps> = ({ onApprove, onReject }) =>
   return (
     <div className="flex items-center gap-1 w-full h-[30px] pt-2">
       <button
-        onClick={onStartReject}
+        onClick={() => setHasRejected(true)}
         className="flex-1 h-[30px] flex justify-center items-center bg-red-100 border border-red-500 text-red-500 hover:bg-red-200 hover:text-red-600 transition-colors rounded"
         aria-label="Reject change"
         title="Reject change"

--- a/app/components/chat/ApproveChange.tsx
+++ b/app/components/chat/ApproveChange.tsx
@@ -1,4 +1,6 @@
-import React from 'react';
+import React, { useState } from 'react';
+import { classNames } from '~/utils/classNames';
+import { TEXTAREA_MIN_HEIGHT } from './BaseChat';
 
 interface ApproveChangeProps {
   onApprove: () => void;
@@ -6,10 +8,81 @@ interface ApproveChangeProps {
 }
 
 const ApproveChange: React.FC<ApproveChangeProps> = ({ onApprove, onReject }) => {
+  const [hasRejected, setHasRejected] = useState(false);
+
+  const onStartReject = () => {
+    setHasRejected(true);
+  };
+
+  if (hasRejected) {
+    return (
+      <>
+        <div
+          className={classNames(
+            'relative shadow-xs border border-bolt-elements-borderColor backdrop-blur rounded-lg bg-red-50 mt-3',
+          )}
+        >
+          <textarea
+            className={classNames(
+              'w-full pl-4 pt-4 pr-25 outline-none resize-none text-bolt-elements-textPrimary placeholder-bolt-elements-textTertiary bg-transparent text-sm',
+              'transition-all duration-200',
+              'hover:border-bolt-elements-focus'
+            )}
+            onKeyDown={(event) => {
+              if (event.key === 'Enter') {
+                if (event.shiftKey) {
+                  return;
+                }
+
+                event.preventDefault();
+              }
+            }}
+            style={{
+              minHeight: TEXTAREA_MIN_HEIGHT,
+              maxHeight: 400,
+            }}
+            placeholder="What is wrong with our changes?"
+            translate="no"
+          />
+        </div>
+        
+        <div className="flex items-center gap-2 w-full mb-2">
+          <input
+            type="checkbox"
+            id="share-project"
+            className="rounded border-red-300 text-red-500 focus:ring-red-500"
+          />
+          <label htmlFor="share-project" className="text-sm text-red-600">
+            Share with Nut team
+          </label>
+        </div>
+
+        <div className="flex items-center gap-1 w-full h-[30px] pt-2">
+          <button
+            onClick={() => {}}
+            className="flex-1 h-[30px] flex justify-center items-center bg-red-100 border border-red-500 text-red-500 hover:bg-red-200 hover:text-red-600 transition-colors rounded"
+            aria-label="Cancel changes"
+            title="Cancel changes"
+          >
+            <div className="i-ph:x-bold"></div>
+          </button>
+          <button
+            onClick={() => {}}
+            className="flex-1 h-[30px] flex justify-center items-center bg-green-100 border border-green-500 text-green-500 hover:bg-green-200 hover:text-green-600 transition-colors rounded"
+            aria-label="Try changes again"
+            title="Try changes again"
+          >
+            <div className="i-ph:repeat-bold"></div>
+          </button>
+        </div>
+      </>
+    );
+  }
+
   return (
     <div className="flex items-center gap-1 w-full h-[30px] pt-2">
       <button
-        onClick={onReject}
+        onClick={onStartReject}
         className="flex-1 h-[30px] flex justify-center items-center bg-red-100 border border-red-500 text-red-500 hover:bg-red-200 hover:text-red-600 transition-colors rounded"
         aria-label="Reject change"
         title="Reject change"

--- a/app/components/chat/BaseChat.tsx
+++ b/app/components/chat/BaseChat.tsx
@@ -26,6 +26,7 @@ import { ModelSelector } from '~/components/chat/ModelSelector';
 import { SpeechRecognitionButton } from '~/components/chat/SpeechRecognition';
 import { ScreenshotStateManager } from './ScreenshotStateManager';
 import { toast } from 'react-toastify';
+import type { RejectChangeData } from './ApproveChange';
 
 export const TEXTAREA_MIN_HEIGHT = 76;
 
@@ -42,7 +43,7 @@ interface BaseChatProps {
   promptEnhanced?: boolean;
   input?: string;
   handleStop?: () => void;
-  sendMessage?: (event: React.UIEvent, messageInput?: string) => void;
+  sendMessage?: (messageInput?: string) => void;
   handleInputChange?: (event: React.ChangeEvent<HTMLTextAreaElement>) => void;
   enhancePrompt?: () => void;
   importChat?: (description: string, messages: Message[]) => Promise<void>;
@@ -52,6 +53,8 @@ interface BaseChatProps {
   imageDataList?: string[];
   setImageDataList?: (dataList: string[]) => void;
   onRewind?: (messageId: string, contents: string) => void;
+  onApproveChange?: (messageId: string) => void;
+  onRejectChange?: (messageId: string, contents: string, data: RejectChangeData) => void;
 }
 
 export const BaseChat = React.forwardRef<HTMLDivElement, BaseChatProps>(
@@ -79,6 +82,8 @@ export const BaseChat = React.forwardRef<HTMLDivElement, BaseChatProps>(
       setImageDataList,
       messages,
       onRewind,
+      onApproveChange,
+      onRejectChange,
     },
     ref,
   ) => {
@@ -141,7 +146,7 @@ export const BaseChat = React.forwardRef<HTMLDivElement, BaseChatProps>(
 
     const handleSendMessage = (event: React.UIEvent, messageInput?: string) => {
       if (sendMessage) {
-        sendMessage(event, messageInput);
+        sendMessage(messageInput);
 
         if (recognition) {
           recognition.abort(); // Stop current recognition
@@ -244,6 +249,8 @@ export const BaseChat = React.forwardRef<HTMLDivElement, BaseChatProps>(
                       messages={messages}
                       isStreaming={isStreaming}
                       onRewind={onRewind}
+                      onApproveChange={onApproveChange}
+                      onRejectChange={onRejectChange}
                     />
                   ) : null;
                 }}

--- a/app/components/chat/BaseChat.tsx
+++ b/app/components/chat/BaseChat.tsx
@@ -53,8 +53,9 @@ interface BaseChatProps {
   imageDataList?: string[];
   setImageDataList?: (dataList: string[]) => void;
   onRewind?: (messageId: string, contents: string) => void;
+  approveChangesMessageId?: string;
   onApproveChange?: (messageId: string) => void;
-  onRejectChange?: (messageId: string, contents: string, data: RejectChangeData) => void;
+  onRejectChange?: (lastMessageId: string, rewindMessageId: string, contents: string, data: RejectChangeData) => void;
 }
 
 export const BaseChat = React.forwardRef<HTMLDivElement, BaseChatProps>(
@@ -82,6 +83,7 @@ export const BaseChat = React.forwardRef<HTMLDivElement, BaseChatProps>(
       setImageDataList,
       messages,
       onRewind,
+      approveChangesMessageId,
       onApproveChange,
       onRejectChange,
     },
@@ -249,6 +251,7 @@ export const BaseChat = React.forwardRef<HTMLDivElement, BaseChatProps>(
                       messages={messages}
                       isStreaming={isStreaming}
                       onRewind={onRewind}
+                      approveChangesMessageId={approveChangesMessageId}
                       onApproveChange={onApproveChange}
                       onRejectChange={onRejectChange}
                     />

--- a/app/components/chat/BaseChat.tsx
+++ b/app/components/chat/BaseChat.tsx
@@ -27,7 +27,7 @@ import { SpeechRecognitionButton } from '~/components/chat/SpeechRecognition';
 import { ScreenshotStateManager } from './ScreenshotStateManager';
 import { toast } from 'react-toastify';
 
-const TEXTAREA_MIN_HEIGHT = 76;
+export const TEXTAREA_MIN_HEIGHT = 76;
 
 interface BaseChatProps {
   textareaRef?: React.RefObject<HTMLTextAreaElement> | undefined;

--- a/app/components/chat/BaseChat.tsx
+++ b/app/components/chat/BaseChat.tsx
@@ -42,7 +42,7 @@ interface BaseChatProps {
   promptEnhanced?: boolean;
   input?: string;
   handleStop?: () => void;
-  sendMessage?: (event: React.UIEvent, messageInput?: string, simulation?: boolean) => void;
+  sendMessage?: (event: React.UIEvent, messageInput?: string) => void;
   handleInputChange?: (event: React.ChangeEvent<HTMLTextAreaElement>) => void;
   enhancePrompt?: () => void;
   importChat?: (description: string, messages: Message[]) => Promise<void>;
@@ -139,9 +139,9 @@ export const BaseChat = React.forwardRef<HTMLDivElement, BaseChatProps>(
       }
     };
 
-    const handleSendMessage = (event: React.UIEvent, messageInput?: string, simulation?: boolean) => {
+    const handleSendMessage = (event: React.UIEvent, messageInput?: string) => {
       if (sendMessage) {
-        sendMessage(event, messageInput, simulation);
+        sendMessage(event, messageInput);
 
         if (recognition) {
           recognition.abort(); // Stop current recognition
@@ -377,33 +377,15 @@ export const BaseChat = React.forwardRef<HTMLDivElement, BaseChatProps>(
                   />
                   <ClientOnly>
                     {() => (
-                      <>
-                        <SendButton
-                          show={input.length > 0 || isStreaming || uploadedFiles.length > 0}
-                          fixBug={false}
-                          isStreaming={isStreaming}
-                          onClick={(event) => {
-                            if (isStreaming) {
-                              handleStop?.();
-                              return;
-                            }
-
-                            if (input.length > 0 || uploadedFiles.length > 0) {
-                              handleSendMessage?.(event);
-                            }
-                          }}
-                        />
-                        <SendButton
-                          show={(input.length > 0 || uploadedFiles.length > 0) && chatStarted}
-                          fixBug={true}
-                          isStreaming={isStreaming}
-                          onClick={(event) => {
-                            if (input.length > 0 || uploadedFiles.length > 0) {
-                              handleSendMessage?.(event, undefined, true);
-                            }
-                          }}
-                        />
-                      </>
+                      <SendButton
+                        show={(input.length > 0 || uploadedFiles.length > 0) && chatStarted}
+                        isStreaming={isStreaming}
+                        onClick={(event) => {
+                          if (input.length > 0 || uploadedFiles.length > 0) {
+                            handleSendMessage?.(event);
+                          }
+                        }}
+                      />
                     )}
                   </ClientOnly>
                   <div className="flex justify-between items-center text-sm p-4 pt-2">

--- a/app/components/chat/Chat.client.tsx
+++ b/app/components/chat/Chat.client.tsx
@@ -30,6 +30,7 @@ import { anthropicNumFreeUsesCookieName, anthropicApiKeyCookieName, MaxFreeUses 
 import type { FileMap } from '~/lib/stores/files';
 import { shouldIncludeFile } from '~/utils/fileUtils';
 import { getNutLoginKey } from '~/lib/replay/Problems';
+import { shouldUseSimulation } from '~/lib/hooks/useSimulation';
 
 const toastAnimation = cssTransition({
   enter: 'animated fadeInRight',
@@ -327,7 +328,7 @@ export const ChatImpl = memo(
       return { enhancedPrompt, enhancedPromptMessage };
     }
 
-    const sendMessage = async (_event: React.UIEvent, messageInput?: string, simulation?: boolean) => {
+    const sendMessage = async (_event: React.UIEvent, messageInput?: string) => {
       const _input = messageInput || input;
       const numAbortsAtStart = gNumAborts;
 
@@ -362,6 +363,14 @@ export const ChatImpl = memo(
       await workbenchStore.saveAllFiles();
 
       let simulationEnhancedPrompt: string | undefined;
+
+      const simulation = await shouldUseSimulation(messages, _input);
+
+      if (numAbortsAtStart != gNumAborts) {
+        return;
+      }
+
+      console.log("UseSimulation", simulation);
 
       if (simulation) {
         gLockSimulationData = true;

--- a/app/components/chat/Chat.client.tsx
+++ b/app/components/chat/Chat.client.tsx
@@ -31,6 +31,7 @@ import type { FileMap } from '~/lib/stores/files';
 import { shouldIncludeFile } from '~/utils/fileUtils';
 import { getNutLoginKey } from '~/lib/replay/Problems';
 import { shouldUseSimulation } from '~/lib/hooks/useSimulation';
+import type { RejectChangeData } from './ApproveChange';
 
 const toastAnimation = cssTransition({
   enter: 'animated fadeInRight',
@@ -328,7 +329,7 @@ export const ChatImpl = memo(
       return { enhancedPrompt, enhancedPromptMessage };
     }
 
-    const sendMessage = async (_event: React.UIEvent, messageInput?: string) => {
+    const sendMessage = async (messageInput?: string) => {
       const _input = messageInput || input;
       const numAbortsAtStart = gNumAborts;
 
@@ -473,6 +474,27 @@ export const ChatImpl = memo(
       }
     };
 
+    const onApproveChange = (messageId: string) => {
+      console.log("ApproveChange", messageId);
+    };
+
+    const onRejectChange = async (messageId: string, projectContents: string, data: RejectChangeData) => {
+      console.log("RejectChange", messageId, data);
+
+      const message = messages.find((message) => message.id === messageId);
+      const messageContents = message?.content ?? "";
+
+      await onRewind(messageId, projectContents);
+
+      if (data.shareProject) {
+        throw new Error("FIXME");
+      }
+
+      if (data.retry) {
+        sendMessage(messageContents);
+      }
+    };
+
     /**
      * Handles the change event for the textarea and updates the input state.
      * @param event - The change event from the textarea.
@@ -544,6 +566,8 @@ export const ChatImpl = memo(
         imageDataList={imageDataList}
         setImageDataList={setImageDataList}
         onRewind={onRewind}
+        onApproveChange={onApproveChange}
+        onRejectChange={onRejectChange}
       />
     );
   },

--- a/app/components/chat/Messages.client.tsx
+++ b/app/components/chat/Messages.client.tsx
@@ -8,6 +8,7 @@ import { forkChat } from '~/lib/persistence/db';
 import { toast } from 'react-toastify';
 import WithTooltip from '~/components/ui/Tooltip';
 import { assert, sendCommandDedicatedClient } from '~/lib/replay/ReplayProtocolClient';
+import ApproveChange from './ApproveChange';
 
 interface MessagesProps {
   id?: string;
@@ -55,6 +56,27 @@ export const Messages = React.forwardRef<HTMLDivElement, MessagesProps>((props: 
     }
     return { messageId: beforeUserMessage.id, contents };
   };
+
+  /*
+  const showApproveChange = (() => {
+    if (isStreaming) {
+      return false;
+    }
+
+    if (!messages.length) {
+      return false;
+    }
+
+    const lastMessageProjectContents = getLastMessageProjectContents(messages.length - 1);
+    if (!lastMessageProjectContents) {
+      return false;
+    }
+
+    const lastMessage = messages[messages.length - 1];
+    return hasFileModifications(lastMessage.content);
+  })();
+  */
+  const showApproveChange = true;
 
   return (
     <div id={id} ref={ref} className={props.className}>
@@ -122,6 +144,9 @@ export const Messages = React.forwardRef<HTMLDivElement, MessagesProps>((props: 
         : null}
       {isStreaming && (
         <div className="text-center w-full text-bolt-elements-textSecondary i-svg-spinners:3-dots-fade text-4xl mt-4"></div>
+      )}
+      {showApproveChange && (
+        <ApproveChange onApprove={() => {}} onReject={() => {}} />
       )}
     </div>
   );

--- a/app/components/chat/Messages.client.tsx
+++ b/app/components/chat/Messages.client.tsx
@@ -34,6 +34,8 @@ function hasFileModifications(content: string) {
   return content.includes('__boltArtifact__');
 }
 
+const gApprovedOrRejectedMessageIds = new Set<string>();
+
 export const Messages = React.forwardRef<HTMLDivElement, MessagesProps>((props: MessagesProps, ref) => {
   const { id, isStreaming = false, messages = [], onRewind, onApproveChange, onRejectChange } = props;
 
@@ -58,7 +60,6 @@ export const Messages = React.forwardRef<HTMLDivElement, MessagesProps>((props: 
     return { messageId: beforeUserMessage.id, contents };
   };
 
-  /*
   const showApproveChange = (() => {
     if (isStreaming) {
       return false;
@@ -74,10 +75,13 @@ export const Messages = React.forwardRef<HTMLDivElement, MessagesProps>((props: 
     }
 
     const lastMessage = messages[messages.length - 1];
+
+    if (gApprovedOrRejectedMessageIds.has(lastMessage.id)) {
+      return false;
+    }
+
     return hasFileModifications(lastMessage.content);
   })();
-  */
-  const showApproveChange = true;
 
   return (
     <div id={id} ref={ref} className={props.className}>
@@ -152,6 +156,7 @@ export const Messages = React.forwardRef<HTMLDivElement, MessagesProps>((props: 
             if (onApproveChange) {
               const lastMessage = messages[messages.length - 1];
               assert(lastMessage);
+              gApprovedOrRejectedMessageIds.add(lastMessage.id);
               onApproveChange(lastMessage.id);
             }
           }}
@@ -159,6 +164,7 @@ export const Messages = React.forwardRef<HTMLDivElement, MessagesProps>((props: 
             if (onRejectChange) {
               const lastMessage = messages[messages.length - 1];
               assert(lastMessage);
+              gApprovedOrRejectedMessageIds.add(lastMessage.id);
 
               const info = getLastMessageProjectContents(messages.length - 1);
               assert(info);

--- a/app/components/chat/Messages.client.tsx
+++ b/app/components/chat/Messages.client.tsx
@@ -39,8 +39,7 @@ export const Messages = React.forwardRef<HTMLDivElement, MessagesProps>((props: 
     // The message index is for the model response, and the project
     // contents will be associated with the last message present when
     // the user prompt was sent to the model. This could be either two
-    // or three messages back, depending on whether the "fix bug"
-    // button was clicked.
+    // or three messages back, depending on whether a bug explanation was added.
     const beforeUserMessage = messages[index - 2];
     const contents = gProjectContentsByMessageId.get(beforeUserMessage?.id);
     if (!contents) {

--- a/app/components/chat/SendButton.client.tsx
+++ b/app/components/chat/SendButton.client.tsx
@@ -2,7 +2,6 @@ import { AnimatePresence, cubicBezier, motion } from 'framer-motion';
 
 interface SendButtonProps {
   show: boolean;
-  fixBug: boolean;
   isStreaming?: boolean;
   disabled?: boolean;
   onClick?: (event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => void;
@@ -11,17 +10,13 @@ interface SendButtonProps {
 
 const customEasingFn = cubicBezier(0.4, 0, 0.2, 1);
 
-export const SendButton = ({ show, fixBug, isStreaming, disabled, onClick }: SendButtonProps) => {
-  const className = fixBug
-    ? "absolute flex justify-center items-center top-[18px] right-[60px] p-1 bg-accent-500 hover:brightness-94 color-white rounded-md w-[34px] h-[34px] transition-theme disabled:opacity-50 disabled:cursor-not-allowed"
-    : "absolute flex justify-center items-center top-[18px] right-[22px] p-1 bg-accent-500 hover:brightness-94 color-white rounded-md w-[34px] h-[34px] transition-theme disabled:opacity-50 disabled:cursor-not-allowed";
+export const SendButton = ({ show, isStreaming, disabled, onClick }: SendButtonProps) => {
+  const className = "absolute flex justify-center items-center top-[18px] right-[22px] p-1 bg-accent-500 hover:brightness-94 color-white rounded-md w-[34px] h-[34px] transition-theme disabled:opacity-50 disabled:cursor-not-allowed";
 
   // Determine tooltip text based on button state
-  const tooltipText = fixBug
-    ? "Fix Bug"
-    : isStreaming
+  const tooltipText = isStreaming
     ? "Stop Generation"
-    : "Make Improvement";
+    : "Chat";
 
   return (
     <AnimatePresence>
@@ -43,11 +38,9 @@ export const SendButton = ({ show, fixBug, isStreaming, disabled, onClick }: Sen
           }}
         >
           <div className="text-lg">
-            {fixBug
-              ? <div className="i-ph:bug-fill"></div>
-              : !isStreaming
-                ? <div className="i-ph:hand-fill"></div>
-                : <div className="i-ph:stop-circle-bold"></div>}
+            {!isStreaming
+             ? <div className="i-ph:hand-fill"></div>
+             : <div className="i-ph:stop-circle-bold"></div>}
           </div>
         </motion.button>
       ) : null}

--- a/app/lib/hooks/pingTelemetry.ts
+++ b/app/lib/hooks/pingTelemetry.ts
@@ -1,0 +1,13 @@
+
+// FIXME ping telemetry server directly instead of going through the server.
+export async function pingTelemetry(event: string, data: any) {
+  const requestBody: any = {
+    event,
+    data,
+  };
+
+  await fetch('/api/ping-telemetry', {
+    method: 'POST',
+    body: JSON.stringify(requestBody),
+  });
+}

--- a/app/lib/hooks/useSimulation.ts
+++ b/app/lib/hooks/useSimulation.ts
@@ -1,0 +1,16 @@
+import type { Message } from 'ai';
+
+export async function shouldUseSimulation(messages: Message[], messageInput: string) {
+  const requestBody: any = {
+    messages,
+    messageInput,
+  };
+
+  const response = await fetch('/api/use-simulation', {
+    method: 'POST',
+    body: JSON.stringify(requestBody),
+  });
+
+  const result = await response.json() as any;
+  return "useSimulation" in result && !!result.useSimulation;
+}

--- a/app/routes/api.ping-telemetry.ts
+++ b/app/routes/api.ping-telemetry.ts
@@ -1,4 +1,4 @@
-import { type ActionFunctionArgs } from '@remix-run/cloudflare';
+import { json, type ActionFunctionArgs } from '@remix-run/cloudflare';
 import { getCurrentSpan, wrapWithSpan } from '~/lib/.server/otel';
 
 export async function action(args: ActionFunctionArgs) {
@@ -22,5 +22,7 @@ const pingTelemetryAction = wrapWithSpan(
       "telemetry.event": event,
       "telemetry.data": data,
     });
+
+    return json({ success: true });
   }
 );

--- a/app/routes/api.ping-telemetry.ts
+++ b/app/routes/api.ping-telemetry.ts
@@ -1,0 +1,26 @@
+import { type ActionFunctionArgs } from '@remix-run/cloudflare';
+import { getCurrentSpan, wrapWithSpan } from '~/lib/.server/otel';
+
+export async function action(args: ActionFunctionArgs) {
+  return pingTelemetryAction(args);
+}
+
+const pingTelemetryAction = wrapWithSpan(
+  {
+    name: "ping-telemetry",
+  },
+  async function pingTelemetryAction({ context, request }: ActionFunctionArgs) {
+    const { event, data } = await request.json<{
+      event: string;
+      data: any;
+    }>();
+
+    console.log("PingTelemetry", event, data);
+
+    const span = getCurrentSpan();
+    span?.setAttributes({
+      "telemetry.event": event,
+      "telemetry.data": data,
+    });
+  }
+);

--- a/app/routes/api.use-simulation.ts
+++ b/app/routes/api.use-simulation.ts
@@ -47,7 +47,7 @@ reasoning and then respond with either \`<analyze>true</analyze>\` or \`<analyze
 
   const match = /<analyze>(.*?)<\/analyze>/.exec(responseText);
   if (match) {
-    const useSimulation = match[1];
+    const useSimulation = match[1] === "true";
     return json({ useSimulation });
   } else {
     return json({ useSimulation: false });


### PR DESCRIPTION
We need to simplify the prompting mechanism in Nut to only have a single prompt button, and approve prompt results to make it easier to rewind and gather feedback.