### PR TITLE
Fix bug with saved loginKey

### DIFF
--- a/app/routes/problem.$id.tsx
+++ b/app/routes/problem.$id.tsx
@@ -14,7 +14,7 @@ import {
   deleteProblem as backendDeleteProblem,
   BoltProblemStatus,
 } from '~/lib/replay/Problems';
-import { isAdminStore, usernameStore } from '~/lib/stores/user';
+import { useAdminStatus, usernameStore } from '~/lib/stores/user';
 import type { BoltProblem, BoltProblemComment } from '~/lib/replay/Problems';
 
 function Comments({ comments }: { comments: BoltProblemComment[] }) {
@@ -229,7 +229,7 @@ const Nothing = () => null;
 function ViewProblemPage() {
   const params = useParams();
   const problemId = params.id;
-  const isAdmin = useStore(isAdminStore);
+  const { isAdmin } = useAdminStatus();
 
   if (typeof problemId !== 'string') {
     throw new Error('Problem ID is required');

--- a/tests/e2e/problem.spec.ts
+++ b/tests/e2e/problem.spec.ts
@@ -94,3 +94,20 @@ test('Should be able to update a problem', async ({ page }) => {
   await page.getByRole('button', { name: 'Set Status' }).click();
   await page.locator('span').filter({ hasText: 'Pending' }).click();
 });
+
+test('Confirm that isAdmin is saved correctly', async ({ page }) => {
+  await page.goto('/problems?showAll=true');
+  await page.getByRole('combobox').selectOption('all');
+  await page.getByRole('link', { name: '[test] playwright' }).first().click();
+
+  if (await isSupabaseEnabled(page)) {
+    expect(true).toBe(true);
+    return;
+  }
+
+  await setLoginKey(page);
+  await expect(await page.getByRole('button', { name: 'Set Status' })).toBeVisible();
+
+  await page.reload();
+  await expect(await page.getByRole('button', { name: 'Set Status' })).toBeVisible();
+});


### PR DESCRIPTION
  This PR enhances how we verify and maintain admin status throughout the application:

  - Add server-side validation of admin status when a login key is available
  - Update admin cookie when server status differs from stored value
  - Verify admin status when loading problem pages
  - Add end-to-end test to confirm admin status persists after page reload
  - Fix bug with saved loginKey not being persisted on navigation
