### PR TITLE
Fix redirect after google signin

### DIFF
--- a/app/components/auth/ClientAuth.tsx
+++ b/app/components/auth/ClientAuth.tsx
@@ -88,6 +88,9 @@ export function ClientAuth() {
   const handleGoogleSignIn = async () => {
     const { error } = await getSupabase().auth.signInWithOAuth({
       provider: 'google',
+      options: {
+        redirectTo: window.location.origin,
+      },
     });
     console.log('GoogleSignIn', error);
   };


### PR DESCRIPTION
Currently after signing in to google on nut.new it redirects to localhost:3000