### PR TITLE
Set input using prompt search param

### DIFF
--- a/app/components/chat/Chat.client.tsx
+++ b/app/components/chat/Chat.client.tsx
@@ -196,8 +196,7 @@ export const ChatImpl = memo((props: ChatProps) => {
     const prompt = searchParams.get('prompt');
 
     if (prompt) {
-      setSearchParams({});
-      sendMessage(prompt);
+      setInput(prompt);
     }
   }, [searchParams]);
 


### PR DESCRIPTION
Currently the prompt search param sends a message immediately, which doesn't actually work.  It would be better to set the input field, which makes it easier to share links for creating a project.