### PR TITLE
Clear search params when creating new chat

### DIFF
--- a/app/lib/persistence/useChatHistory.ts
+++ b/app/lib/persistence/useChatHistory.ts
@@ -108,6 +108,7 @@ function navigateChat(nextId: string) {
    */
   const url = new URL(window.location.href);
   url.pathname = `/chat/${nextId}`;
+  url.search = '';
 
   window.history.replaceState({}, '', url);
 }


### PR DESCRIPTION
Otherwise the search params like ?prompt=... show up after starting a new chat from the prompt.