### PR TITLE
Check for message category presence

### DIFF
--- a/app/components/chat/Messages.client.tsx
+++ b/app/components/chat/Messages.client.tsx
@@ -84,7 +84,7 @@ export const Messages = React.forwardRef<HTMLDivElement, MessagesProps>((props: 
     const isFirst = index === 0;
     const isLast = index === messages.length - 1;
 
-    if (!isUserMessage && message.category !== 'UserResponse') {
+    if (!isUserMessage && message.category && message.category !== 'UserResponse') {
       const lastUserResponse = getLastUserResponse(index);
       if (!lastUserResponse) {
         return null;


### PR DESCRIPTION
We should only be using the new message category logic for newer chats that have categories, otherwise we won't render anything.