### PR TITLE
Ignore failed `pingTelemetry` requests

### DIFF
--- a/app/lib/hooks/pingTelemetry.ts
+++ b/app/lib/hooks/pingTelemetry.ts
@@ -10,7 +10,7 @@ export async function pingTelemetry(event: string, data: any) {
   fetch('/api/ping-telemetry', {
     method: 'POST',
     body: JSON.stringify(requestBody),
-  });
+  }).catch(() => {});
 }
 
 // Manage telemetry events for a single chat message.


### PR DESCRIPTION
Failed fetched here were reported by Sentry. It's worth suppresing those with a `noop` catch handler