### PR TITLE
Don't hide initial app features if search result was unsuccessful

### DIFF
--- a/app/components/chat/Messages/Messages.client.tsx
+++ b/app/components/chat/Messages/Messages.client.tsx
@@ -247,7 +247,9 @@ export const Messages = React.forwardRef<HTMLDivElement, MessagesProps>(
         if (category === USER_RESPONSE_CATEGORY) {
           return false;
         }
-        if (category === SEARCH_ARBORETUM_CATEGORY) {
+        // Only return on successful searches. Failed searches do not have
+        // a valid result.
+        if (category === SEARCH_ARBORETUM_CATEGORY && parseSearchArboretumResult(messages[i])) {
           return true;
         }
       }


### PR DESCRIPTION
When searching the arboretum fails we hid the initial app features but there was no search result to show later so no features at all are listed.