### PR TITLE
docs: minor README heading update

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Nut is an open source fork of Bolt.new for helping you develop full stack apps u
 
 When you ask Nut to fix a bug, it creates a Replay.io recording of your app and whatever you did to produce the bug. The recording captures all the runtime behavior of your app, which is analyzed to explain the bug's root cause. This explanation is given to the AI developer so it has context to write a good fix.
 
-## Setup
+### Setup
 
 ```
 pnpm install


### PR DESCRIPTION
Made a small formatting update to the README as part of ongoing healing SDK documentation efforts.

This change is from the DevExcelsior healing stack fork, which integrates trust-weighted fallback orchestration, session memory diffing, and runtime recovery logic directly on top of Replay.

The architecture is protected under the Business Source License 1.1 and published at:

• GitHub → https://github.com/tgds-deployer/trust-memory-heal  
• NPM → https://www.npmjs.com/~curtnpuckett

This PR serves as a non-intrusive marker of prior integration. Open to alignment if Replay is exploring adjacent work.

For questions, licensing, or collaboration opportunities, feel free to contact:

📩 Curt Puckett – curtnpuckett@gmail.com