### PR TITLE
Fix problems regenerating chat simulation

### DIFF
--- a/app/lib/replay/ChatManager.ts
+++ b/app/lib/replay/ChatManager.ts
@@ -196,15 +196,21 @@ class ChatManager {
     if (this.repositoryId) {
       const packet = createRepositoryIdPacket(this.repositoryId);
 
-      await this.client.sendCommand({
-        method: 'Nut.addSimulation',
-        params: {
-          chatId,
-          simulationData: [packet, ...this.pageData],
-          completeData: true,
-          saveRecording: true,
-        },
-      });
+      try {
+        await this.client.sendCommand({
+          method: 'Nut.addSimulation',
+          params: {
+            chatId,
+            version: simulationDataVersion,
+            simulationData: [packet, ...this.pageData],
+            completeData: true,
+            saveRecording: true,
+          },
+        });
+      } catch (e) {
+        // Simulation will error if for example the repository doesn't build.
+        console.error('RegenerateChatError', e);
+      }
     }
   }
 


### PR DESCRIPTION
Fixes a missing version and improves robustness so that even if adding the simulation errors (which it can if the development server doesn't start) then we still send the chat message.