### PR TITLE
Add continue building button, fix assorted issues

### DIFF
--- a/app/components/chat/ChatComponent/Chat.client.tsx
+++ b/app/components/chat/ChatComponent/Chat.client.tsx
@@ -7,6 +7,8 @@ import { toast } from 'react-toastify';
 import type { Message } from '~/lib/persistence/message';
 import mergeResponseMessage from './functions/mergeResponseMessages';
 import { getExistingAppResponses } from '~/lib/replay/SendChatMessage';
+import { chatStore } from '~/lib/stores/chat';
+import { database } from '~/lib/persistence/apps';
 
 export function Chat() {
   renderLogger.trace('Chat');
@@ -20,6 +22,7 @@ export function Chat() {
     (async () => {
       try {
         if (appId) {
+          const title = await database.getAppTitle(appId);
           const responses = await getExistingAppResponses(appId);
           let messages: Message[] = [];
           for (const response of responses) {
@@ -27,6 +30,8 @@ export function Chat() {
               messages = mergeResponseMessage(response.message, messages);
             }
           }
+          chatStore.currentAppId.set(appId);
+          chatStore.appTitle.set(title);
           setInitialMessages(messages);
           setReady(true);
         }

--- a/app/components/chat/MessageInput/MessageInput.tsx
+++ b/app/components/chat/MessageInput/MessageInput.tsx
@@ -205,6 +205,16 @@ export const MessageInput: React.FC<MessageInputProps> = ({
                   const message = (fullInput + '\n\nStart building the app based on these requirements.').trim();
                   handleSendMessage(event, message, true, ChatMode.BuildApp);
                 }}
+                hasAppSummary={false}
+              />
+            )}
+            {hasAppSummary && !hasPendingMessage && (
+              <StartPlanningButton
+                onClick={(event) => {
+                  const message = 'Continue building the app.';
+                  handleSendMessage(event, message, true, ChatMode.DevelopApp);
+                }}
+                hasAppSummary={true}
               />
             )}
           </>

--- a/app/components/chat/StartPlanningButton.tsx
+++ b/app/components/chat/StartPlanningButton.tsx
@@ -4,13 +4,14 @@ import WithTooltip from '~/components/ui/Tooltip';
 
 interface StartPlanningButtonProps {
   onClick?: (event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => void;
+  hasAppSummary?: boolean;
 }
 
 const customEasingFn = cubicBezier(0.4, 0, 0.2, 1);
 
-export const StartPlanningButton = ({ onClick }: StartPlanningButtonProps) => {
+export const StartPlanningButton = ({ onClick, hasAppSummary }: StartPlanningButtonProps) => {
   const className = `absolute flex justify-center items-center bottom-[50px] right-[22px] p-2 bg-blue-500 hover:bg-blue-600 color-white rounded-md h-[34px] w-[34px] transition-theme disabled:opacity-50 disabled:cursor-not-allowed`;
-  const tooltipText = 'Start Building Now!';
+  const tooltipText = hasAppSummary ? 'Continue Building' : 'Start Building Now!';
 
   return (
     <AnimatePresence>

--- a/app/lib/replay/SendChatMessage.ts
+++ b/app/lib/replay/SendChatMessage.ts
@@ -4,7 +4,7 @@
 
 import type { SimulationData, SimulationPacket } from './SimulationData';
 import { assert } from '~/utils/nut';
-import type { Message } from '~/lib/persistence/message';
+import { type Message, USER_RESPONSE_CATEGORY } from '~/lib/persistence/message';
 import { chatStore } from '~/lib/stores/chat';
 import { sendChatMessageMocked, usingMockChat } from './MockChat';
 import { flushSimulationData } from '~/components/chat/ChatComponent/functions/flushSimulation';
@@ -96,6 +96,10 @@ interface NutChatRequest {
   workerCount?: number;
 }
 
+function shouldSendMessage(message: Message) {
+  return message.role == 'user' || message.category == USER_RESPONSE_CATEGORY;
+}
+
 export async function sendChatMessage(
   mode: ChatMode,
   messages: Message[],
@@ -126,7 +130,7 @@ export async function sendChatMessage(
   const params: NutChatRequest = {
     appId: chatStore.currentAppId.get(),
     mode,
-    messages,
+    messages: messages.filter(shouldSendMessage),
     references,
     simulationData,
   };


### PR DESCRIPTION
This adds a button analogous to the "Start Planning" button for use when there is already an app summary.  This is in the same place and instead of short circuiting the planning process it jumps right into continuing to build the remaining features.

This also fixes a couple bugs around loading and sending messages to existing apps.