### PR TITLE
rename chats to apps in the UI, remove some obsolete functionality

### DIFF
--- a/app/components/sidebar/Menu.client.tsx
+++ b/app/components/sidebar/Menu.client.tsx
@@ -82,7 +82,7 @@ export const Menu = () => {
           }
         })
         .catch((error) => {
-          toast.error('Failed to delete conversation');
+          toast.error('Failed to delete app');
           logger.error(error);
         });
     },
@@ -209,7 +209,7 @@ export const Menu = () => {
             className="flex gap-2 items-center bg-bolt-elements-sidebar-buttonBackgroundDefault text-bolt-elements-sidebar-buttonText hover:bg-bolt-elements-sidebar-buttonBackgroundHover rounded-md p-2 transition-theme mb-4"
           >
             <span className="inline-block i-bolt:chat scale-110" />
-            Start new chat
+            New App
           </a>
           <div className="relative w-full">
             <input
@@ -221,11 +221,11 @@ export const Menu = () => {
             />
           </div>
         </div>
-        <div className="text-bolt-elements-textPrimary font-medium pl-6 pr-5 my-2">Your Chats</div>
+        <div className="text-bolt-elements-textPrimary font-medium pl-6 pr-5 my-2">Your Apps</div>
         <div className="flex-1 overflow-auto pl-4 pr-5 pb-5">
           {filteredList.length === 0 && (
             <div className="pl-2 text-bolt-elements-textTertiary">
-              {list ? (list.length === 0 ? 'No previous conversations' : 'No matches found') : 'Loading...'}
+              {list ? (list.length === 0 ? 'No apps' : 'No matches found') : 'Loading...'}
             </div>
           )}
           <DialogRoot open={dialogContent !== null}>

--- a/app/lib/replay/SendChatMessage.ts
+++ b/app/lib/replay/SendChatMessage.ts
@@ -97,7 +97,8 @@ interface NutChatRequest {
   workerCount?: number;
 }
 
-function shouldSendMessage(message: Message) {
+// Messages that are rendered normally in the chat.
+export function shouldDisplayMessage(message: Message) {
   return (
     message.role == 'user' ||
     message.category == DISCOVERY_RESPONSE_CATEGORY ||
@@ -135,7 +136,7 @@ export async function sendChatMessage(
   const params: NutChatRequest = {
     appId: chatStore.currentAppId.get(),
     mode,
-    messages: messages.filter(shouldSendMessage),
+    messages: messages.filter(shouldDisplayMessage),
     references,
     simulationData,
   };


### PR DESCRIPTION
https://linear.app/replay/issue/PRO-1646/switch-from-chats-to-projects-in-the-left-nav