### PR TITLE
Preload app development servers

### DIFF
--- a/app/lib/replay/DevelopmentServer.ts
+++ b/app/lib/replay/DevelopmentServer.ts
@@ -18,4 +18,9 @@ export const updateDevelopmentServer = debounce((repositoryId: string | undefine
   workbenchStore.showWorkbench.set(repositoryURL !== undefined);
   workbenchStore.repositoryId.set(repositoryId);
   workbenchStore.previewURL.set(repositoryURL);
+
+  // Prefetch the development server so it will be ready earlier.
+  if (repositoryURL) {
+    fetch(repositoryURL);
+  }
 }, 500);


### PR DESCRIPTION
Development servers in the preview tab are loaded on demand.  This PR fetches them to trigger the preload when the app summary with that server URL appears, reducing the loading wait when clicking on the preview.