### PR TITLE
Add dump method on window

### DIFF
--- a/app/lib/replay/ResponseFilter.ts
+++ b/app/lib/replay/ResponseFilter.ts
@@ -72,3 +72,9 @@ export function getLastResponseTime() {
 export function getAllAppResponses() {
   return Array.from(gResponsesByTime.values()).flat();
 }
+
+if (typeof window !== 'undefined') {
+  (window as any).__NUT_DUMP_RESPONSES__ = () => {
+    console.log(JSON.stringify(getAllAppResponses()));
+  };
+}


### PR DESCRIPTION
Adds a debugging method `window.__NUT_DUMP_RESPONSES__` which logs all the responses to the console.