### PR TITLE
Enable detected errors feature

### DIFF
--- a/app/components/workbench/Preview/Preview.tsx
+++ b/app/components/workbench/Preview/Preview.tsx
@@ -62,11 +62,6 @@ export const Preview = memo(({ activeTab, handleSendMessage }: PreviewProps) => 
 
   // Interval for sending getDetectedErrors message
   useEffect(() => {
-    // For now detected errors are disabled.
-    if (!import.meta.env.VITE_ENABLE_DETECTED_ERRORS) {
-      return;
-    }
-
     if (activeTab === 'preview') {
       let lastDetectedError: DetectedError | undefined = undefined;
       const interval = setInterval(async () => {


### PR DESCRIPTION
Backend functionality is running now that Nut can detect and work on fixing 500 errors detected while the app is running.