### PR TITLE
Remove getLatest methods

### DIFF
--- a/app/components/chat/ChatComponent/components/ChatImplementer/ChatImplementer.tsx
+++ b/app/components/chat/ChatComponent/components/ChatImplementer/ChatImplementer.tsx
@@ -15,8 +15,6 @@ import { getCurrentMouseData } from '~/components/workbench/PointSelector';
 import { ChatMessageTelemetry } from '~/lib/hooks/pingTelemetry';
 import { type Message } from '~/lib/persistence/message';
 // import { usingMockChat } from '~/lib/replay/MockChat';
-import { updateDevelopmentServer } from '~/lib/replay/DevelopmentServer';
-import { getLatestAppRepositoryId, getLatestAppSummary } from '~/lib/persistence/messageAppSummary';
 import { generateRandomId, navigateApp } from '~/utils/nut';
 import type { DetectedError } from '~/lib/replay/MessageHandlerInterface';
 import type { SimulationData } from '~/lib/replay/MessageHandler';
@@ -46,6 +44,7 @@ const ChatImplementer = memo(() => {
   const [input, setInput] = useState('');
 
   const showChat = useStore(chatStore.showChat);
+  const hasAppSummary = !!useStore(chatStore.appSummary);
 
   const [animationScope, animate] = useAnimate();
 
@@ -56,14 +55,6 @@ const ChatImplementer = memo(() => {
       setInput(prompt);
     }
   }, [searchParams]);
-
-  useEffect(() => {
-    const repositoryId = getLatestAppRepositoryId(chatStore.messages.get());
-
-    if (repositoryId) {
-      updateDevelopmentServer(repositoryId);
-    }
-  }, []);
 
   const TEXTAREA_MAX_HEIGHT = chatStarted ? 400 : 200;
 
@@ -176,7 +167,7 @@ const ChatImplementer = memo(() => {
     if (!mode) {
       // If we don't have a plan yet, stay in Discovery mode until the user
       // forces us to start planning.
-      if (!getLatestAppSummary(messages)) {
+      if (!hasAppSummary) {
         mode = ChatMode.Discovery;
       } else {
         mode = ChatMode.BuildApp;

--- a/app/components/chat/MessageInput/MessageInput.tsx
+++ b/app/components/chat/MessageInput/MessageInput.tsx
@@ -7,7 +7,6 @@ import { ChatMode } from '~/lib/replay/SendChatMessage';
 import { StartPlanningButton } from '~/components/chat/StartPlanningButton';
 import { chatStore } from '~/lib/stores/chat';
 import { useStore } from '@nanostores/react';
-import { getLatestAppSummary } from '~/lib/persistence/messageAppSummary';
 import { getDiscoveryRating } from '~/lib/persistence/message';
 import type { ChatMessageParams } from '~/components/chat/ChatComponent/components/ChatImplementer/ChatImplementer';
 
@@ -49,7 +48,7 @@ export const MessageInput: React.FC<MessageInputProps> = ({
   const hasPendingMessage = useStore(chatStore.hasPendingMessage);
   const chatStarted = useStore(chatStore.started);
   const messages = useStore(chatStore.messages);
-  const hasAppSummary = !!getLatestAppSummary(messages || []);
+  const hasAppSummary = !!useStore(chatStore.appSummary);
 
   let startPlanningRating = 0;
   if (!hasPendingMessage && !hasAppSummary) {

--- a/app/components/workbench/Preview/Preview.tsx
+++ b/app/components/workbench/Preview/Preview.tsx
@@ -65,8 +65,6 @@ export const Preview = memo(({ activeTab, handleSendMessage }: PreviewProps) => 
     if (activeTab === 'preview') {
       let lastDetectedError: DetectedError | undefined = undefined;
       const interval = setInterval(async () => {
-        console.log('Checking for detected errors', iframeRef.current);
-
         if (!iframeRef.current) {
           return;
         }

--- a/app/lib/persistence/messageAppSummary.ts
+++ b/app/lib/persistence/messageAppSummary.ts
@@ -187,40 +187,6 @@ export function parseAppSummaryMessage(message: Message): AppSummary | undefined
   }
 }
 
-// Get the latest app summary from messages (use passed messages, not store)
-export const getLatestAppSummary = (messages: Message[]): AppSummary | null => {
-  if (!messages) {
-    return null;
-  }
-
-  // Find the last message with APP_SUMMARY_CATEGORY
-  const appSummaryMessage = messages
-    .slice()
-    .reverse()
-    .find((message) => message.category === APP_SUMMARY_CATEGORY);
-
-  if (!appSummaryMessage) {
-    return null;
-  }
-  return parseAppSummaryMessage(appSummaryMessage) || null;
-};
-
 export function isFeatureStatusImplemented(status?: AppFeatureStatus) {
   return status && status != AppFeatureStatus.NotStarted && status != AppFeatureStatus.ImplementationInProgress;
-}
-
-export function getLatestAppRepositoryId(messages: Message[]) {
-  const appSummary = getLatestAppSummary(messages);
-  if (!appSummary) {
-    return undefined;
-  }
-  // Ignore repositories if no mockup or features have been completed.
-  // This will be an incomplete skeleton app we don't want to show.
-  if (
-    !isFeatureStatusImplemented(appSummary.mockupStatus) &&
-    !appSummary.features?.some((f) => isFeatureStatusImplemented(f.status))
-  ) {
-    return undefined;
-  }
-  return appSummary.repositoryId;
 }


### PR DESCRIPTION
Removes a couple methods that operate on arrays of methods and are no longer the right way of doing this.  I noticed this because it was causing a bug where the "Start Building Now" button could flash unexpectedly, and which this also fixes.