### PR TITLE
Ensure answered discovery messages are no longer interactive

### DIFF
--- a/app/components/chat/BaseChat/BaseChat.tsx
+++ b/app/components/chat/BaseChat/BaseChat.tsx
@@ -17,6 +17,7 @@ import styles from './BaseChat.module.scss';
 import { ExamplePrompts } from '~/components/chat/ExamplePrompts';
 import { type MessageInputProps } from '~/components/chat/MessageInput/MessageInput';
 import { ChatMode } from '~/lib/replay/SendChatMessage';
+import { DISCOVERY_RESPONSE_CATEGORY } from '~/lib/persistence/message';
 import { workbenchStore } from '~/lib/stores/workbench';
 import { mobileNavStore } from '~/lib/stores/mobileNav';
 import { useStore } from '@nanostores/react';
@@ -105,6 +106,16 @@ export const BaseChat = React.forwardRef<HTMLDivElement, BaseChatProps>(
 
     const handleSendMessage = (params: ChatMessageParams) => {
       if (sendMessage) {
+        // Mark discovery messages as interacted when user sends a response
+        const messages = chatStore.messages.get();
+        const updatedMessages = messages.map((message) => {
+          if (message.type === 'text' && message.category === DISCOVERY_RESPONSE_CATEGORY && !message.hasInteracted) {
+            return { ...message, hasInteracted: true };
+          }
+          return message;
+        });
+        chatStore.messages.set(updatedMessages);
+
         sendMessage(params);
         abortListening();
         setCheckedBoxes([]);

--- a/app/components/chat/ChatComponent/components/ChatImplementer/ChatImplementer.tsx
+++ b/app/components/chat/ChatComponent/components/ChatImplementer/ChatImplementer.tsx
@@ -113,6 +113,7 @@ const ChatImplementer = memo(() => {
         role: 'user',
         type: 'text',
         content: messageInput,
+        hasInteracted: false,
       };
 
       addChatMessage(userMessage);

--- a/app/components/chat/ChatComponent/functions/mergeResponseMessages.ts
+++ b/app/components/chat/ChatComponent/functions/mergeResponseMessages.ts
@@ -14,6 +14,7 @@ function mergeResponseMessage(msg: Message, messages: Message[]): Message[] {
     messages.push({
       ...msg,
       content: lastMessage.content + msg.content,
+      hasInteracted: lastMessage.type === 'text' ? lastMessage.hasInteracted || false : false,
     });
   } else {
     messages.push(msg);

--- a/app/components/chat/Markdown.tsx
+++ b/app/components/chat/Markdown.tsx
@@ -65,7 +65,7 @@ export const Markdown = memo((props: MarkdownProps) => {
         return <input type="checkbox" checked={checked ?? false} onChange={handleChange} {...props} />;
       },
     } satisfies Components;
-  }, []);
+  }, [onCheckboxChange]);
 
   return (
     <ReactMarkdown

--- a/app/components/chat/Messages/Messages.client.tsx
+++ b/app/components/chat/Messages/Messages.client.tsx
@@ -103,7 +103,7 @@ export const Messages = React.forwardRef<HTMLDivElement, MessagesProps>(({ onLas
     }
 
     let onCheckboxChange = undefined;
-    if (isActiveDiscoveryResponse(messages, message)) {
+    if (isActiveDiscoveryResponse(messages, message) && !hasInteracted(message)) {
       onCheckboxChange = onLastMessageCheckboxChange;
     }
 
@@ -221,4 +221,8 @@ function isActiveDiscoveryResponse(messages: Message[], message: Message) {
     }
   }
   return false;
+}
+
+function hasInteracted(message: Message): boolean {
+  return message.type === 'text' && message.hasInteracted === true;
 }

--- a/app/lib/persistence/message.ts
+++ b/app/lib/persistence/message.ts
@@ -21,6 +21,7 @@ interface MessageBase {
 export interface MessageText extends MessageBase {
   type: 'text';
   content: string;
+  hasInteracted: boolean;
 }
 
 export interface MessageImage extends MessageBase {

--- a/app/lib/stores/chat.ts
+++ b/app/lib/stores/chat.ts
@@ -57,16 +57,22 @@ function addResponseEvent(response: ChatResponse) {
 }
 
 export function addChatMessage(message: Message) {
+  // Ensure hasInteracted field is set for text messages
+  const processedMessage = message.type === 'text' ? {
+    ...message,
+    hasInteracted: message.hasInteracted ?? false
+  } : message;
+
   // If this is a user message, remember it so we don't add it again when it comes back
   // from the backend.
   addAppResponse({
     kind: 'message',
-    message,
-    time: message.createTime ?? new Date().toISOString(),
+    message: processedMessage,
+    time: processedMessage.createTime ?? new Date().toISOString(),
     chatId: undefined,
   });
 
-  chatStore.messages.set(mergeResponseMessage(message, chatStore.messages.get()));
+  chatStore.messages.set(mergeResponseMessage(processedMessage, chatStore.messages.get()));
 }
 
 export async function doAbortChat() {

--- a/app/lib/stores/chat.ts
+++ b/app/lib/stores/chat.ts
@@ -58,10 +58,13 @@ function addResponseEvent(response: ChatResponse) {
 
 export function addChatMessage(message: Message) {
   // Ensure hasInteracted field is set for text messages
-  const processedMessage = message.type === 'text' ? {
-    ...message,
-    hasInteracted: message.hasInteracted ?? false
-  } : message;
+  const processedMessage =
+    message.type === 'text'
+      ? {
+          ...message,
+          hasInteracted: message.hasInteracted ?? false,
+        }
+      : message;
 
   // If this is a user message, remember it so we don't add it again when it comes back
   // from the backend.

--- a/tests/intercom-jwt.test.ts
+++ b/tests/intercom-jwt.test.ts
@@ -50,7 +50,7 @@ describe('Intercom JWT', () => {
       };
 
       await expect(
-        generateIntercomJWT(userData as any, mockAppSecret, mockAppId)
+        generateIntercomJWT(userData as any, mockAppSecret, mockAppId, mockSigningKey)
       ).rejects.toThrow('user_id is required');
     });
 
@@ -60,7 +60,7 @@ describe('Intercom JWT', () => {
       };
 
       await expect(
-        generateIntercomJWT(userData, '', mockAppId)
+        generateIntercomJWT(userData, '', mockAppId, mockSigningKey)
       ).rejects.toThrow('Intercom app secret is required');
     });
 
@@ -70,7 +70,7 @@ describe('Intercom JWT', () => {
       };
 
       await expect(
-        generateIntercomJWT(userData, mockAppSecret, '')
+        generateIntercomJWT(userData, mockAppSecret, '', mockSigningKey)
       ).rejects.toThrow('Intercom app ID is required');
     });
 


### PR DESCRIPTION
# Summary

  Implements checkbox interaction state tracking to prevent users from modifying checkboxes in discovery messages after they've already responded.

##  Changes

  - Added hasInteracted field to MessageText interface to track user responses
  - Updated checkbox rendering logic to disable interaction for previously responded messages
  - Modified message sending flow to mark all discovery messages as interacted when user responds
  - Ensured proper field initialization for both user-created and backend messages

  Behavior

  - ✅ Users can interact with checkboxes in the latest discovery response
  - ❌ Checkboxes become non-interactive once user sends a response
  - ✅ New discovery messages remain interactive until next user response