### PR TITLE
Wait for development server to start before updating preview URL

### DIFF
--- a/app/lib/stores/workbench.ts
+++ b/app/lib/stores/workbench.ts
@@ -4,6 +4,9 @@ export class WorkbenchStore {
   // The current repository.
   repositoryId = atom<string | undefined>(undefined);
 
+  // Repository we are waiting to start up.
+  pendingRepositoryId = atom<string | undefined>(undefined);
+
   // Any available preview URL for the current repository.
   previewURL = atom<string | undefined>(undefined);
 


### PR DESCRIPTION
This PR uses a new backend API to wait for the app's development server to start up before we update the current repository.  This fixes some 502 errors I've been seeing related to /auth/callback (the agent returns a 502 if any URLs other than / are loaded before the server finishes).  It also shows the nicer new app loading screen instead of the "waiting for app to start" one.