### PR TITLE
Allow overrding the Nut API host

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,3 +12,11 @@ pnpm install
 pnpm build
 pnpm dev
 ```
+
+### Local/Ephemeral Backend Configuration
+
+If you want to use local or ephemeral backends instead of the default production services, you can override the Nut backend API host:
+
+- `VITE_REPLAY_API_HOST` - Override the Nut backend API host (default: `https://dispatch.replay.io`)
+
+Add this to your `.env` file to point to your local backend service.

--- a/app/lib/replay/NutAPI.ts
+++ b/app/lib/replay/NutAPI.ts
@@ -31,7 +31,8 @@ export async function callNutAPI(
   const userId = overrideUserId ?? (await getCurrentUserId());
   const accessToken = await getCurrentAccessToken();
 
-  const url = `https://dispatch.replay.io/nut/${method}`;
+  const apiHost = import.meta.env.VITE_REPLAY_API_HOST || 'https://dispatch.replay.io';
+  const url = `${apiHost}/nut/${method}`;
 
   const headers: HeadersInit = {
     'Content-Type': 'application/json',


### PR DESCRIPTION
Nut will route internal API requests to the value of  `VITE_REPLAY_API_HOST`, otherwise will default to `https://dispatch.replay.io`