### PR TITLE
PRO-2387 send X-Client-Info header for source attribution

### DIFF
--- a/app/lib/replay/NutAPI.ts
+++ b/app/lib/replay/NutAPI.ts
@@ -3,9 +3,9 @@ import type { VisitData } from '~/lib/replay/SendChatMessage';
 
 type ResponseCallback = (response: any) => void;
 
-function nutAppHeaders(userId: string | null, accessToken: string | null): Record<string, string> {
+function legacyBuilderHeaders(userId: string | null, accessToken: string | null): Record<string, string> {
   return {
-    'X-Client-Info': 'nut-app/1.0',
+    'X-Client-Info': 'legacy-builder/1.0',
     'x-user-id': userId ?? '',
     Authorization: accessToken ? `Bearer ${accessToken}` : '',
   };
@@ -52,7 +52,7 @@ export async function callNutAPI(
 
   const headers: HeadersInit = {
     'Content-Type': 'application/json',
-    ...nutAppHeaders(userId, accessToken),
+    ...legacyBuilderHeaders(userId, accessToken),
   };
 
   const fetchOptions: RequestInit = {
@@ -112,7 +112,7 @@ async function callAPIStreamBuffer(method: string, buffer: ArrayBuffer, extraHea
   const accessToken = await getCurrentAccessToken();
 
   const headers: HeadersInit = {
-    ...nutAppHeaders(userId, accessToken),
+    ...legacyBuilderHeaders(userId, accessToken),
     'Content-Type': 'application/octet-stream',
     'Content-Length': buffer.byteLength.toString(),
     ...extraHeaders,
@@ -173,7 +173,7 @@ export async function downloadAttachment(attachmentId: string): Promise<ArrayBuf
   const accessToken = await getCurrentAccessToken();
 
   const headers: HeadersInit = {
-    ...nutAppHeaders(userId, accessToken),
+    ...legacyBuilderHeaders(userId, accessToken),
     'Content-Type': 'application/json',
   };
 

--- a/app/lib/replay/NutAPI.ts
+++ b/app/lib/replay/NutAPI.ts
@@ -3,6 +3,14 @@ import type { VisitData } from '~/lib/replay/SendChatMessage';
 
 type ResponseCallback = (response: any) => void;
 
+function nutAppHeaders(userId: string | null, accessToken: string | null): Record<string, string> {
+  return {
+    'X-Client-Info': 'nut-app/1.0',
+    'x-user-id': userId ?? '',
+    Authorization: accessToken ? `Bearer ${accessToken}` : '',
+  };
+}
+
 // Call the Replay Builder API with the specified method and params.
 //
 // If a response callback is provided, responses are expected to be newline-delimited JSON
@@ -44,8 +52,7 @@ export async function callNutAPI(
 
   const headers: HeadersInit = {
     'Content-Type': 'application/json',
-    'x-user-id': userId ?? '',
-    Authorization: accessToken ? `Bearer ${accessToken}` : '',
+    ...nutAppHeaders(userId, accessToken),
   };
 
   const fetchOptions: RequestInit = {
@@ -105,8 +112,7 @@ async function callAPIStreamBuffer(method: string, buffer: ArrayBuffer, extraHea
   const accessToken = await getCurrentAccessToken();
 
   const headers: HeadersInit = {
-    'x-user-id': userId ?? '',
-    Authorization: accessToken ? `Bearer ${accessToken}` : '',
+    ...nutAppHeaders(userId, accessToken),
     'Content-Type': 'application/octet-stream',
     'Content-Length': buffer.byteLength.toString(),
     ...extraHeaders,
@@ -167,8 +173,7 @@ export async function downloadAttachment(attachmentId: string): Promise<ArrayBuf
   const accessToken = await getCurrentAccessToken();
 
   const headers: HeadersInit = {
-    'x-user-id': userId ?? '',
-    Authorization: accessToken ? `Bearer ${accessToken}` : '',
+    ...nutAppHeaders(userId, accessToken),
     'Content-Type': 'application/json',
   };
 


### PR DESCRIPTION
add `X-Client-Info: legacy-builder/1.0` to all outbound calls to the replay backend via a new `legacyBuilderHeaders()` helper. backend uses the `legacy-builder/` prefix to classify the request as the `legacy-builder` channel in telemetry.

note: this codebase (nut.new) is the deprecated legacy builder; the current builder lives at builder.replay.io. tagging as `legacy-builder` so telemetry can distinguish it from whatever future channel the new builder uses.

## related

- replayio/backend: adds the `replay.client.channel` attribute + inference logic